### PR TITLE
Make sure people have the iOS sim installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A mobile app to consume and demonstrate the [Plaid](https://plaid.com/) API. Bui
 $ sudo npm install -g cordova
 $ cordova platform add ios
 $ cordova build ios
+$ npm install -g ios-sim
 $ cordova emulate ios
 ```
 


### PR DESCRIPTION
Without this step I got the error:

```
ios-sim was not found. Please download, build and install version 3.0.0 or greater from https://github.com/phonegap/ios-sim into your path, or do 'npm install -g ios-sim'
``
```
